### PR TITLE
WIP:update github-actions: allow test of specific version/first release version for all OSs.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,13 +40,12 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - if: contains(matrix.container, 'ubuntu') || contains(matrix.container, 'debian')
-        name: Install Scylla Ubuntu / Debian
-        run: ./server --scylla-version ${{ matrix.version }} ${{ matrix.product }}
-
-      - if: contains(matrix.container, 'centos') || contains(matrix.container, 'amazon') || contains(matrix.container, 'oracle') || contains(matrix.container, 'rockylinux')
-        name: Install Scylla Centos / Amazonlinux / Rockylinux / Oracle
+      - name: Install Scylla - first release
         run: ./server --scylla-version ${{ matrix.version }}.0 ${{ matrix.product }}
+
+      - if: contains(matrix.container, 'ubuntu') || contains(matrix.container, 'debian')
+        name: Install Scylla Ubuntu / Debian - latest in version
+        run: ./server --scylla-version ${{ matrix.version }} ${{ matrix.product }}
 
   test_latest:
     name: Test installation for latest version


### PR DESCRIPTION
Follow the fix in: #40 , the github-actions test was updated - the limitation to install specific version on RPM-based OSs only was removed.
The tests of specific version/first release version will be run on all OSs including Ubuntu and Debian.

Closes: #42