### PR TITLE
Fix to able to install scylla on CentOS8

### DIFF
--- a/server
+++ b/server
@@ -383,7 +383,7 @@ amzn_install() {
 
 check_centos_version() {
   case "$VERSION_ID" in
-    "7"|8.?)
+    7*|8*)
       return 1
       ;;
     *)


### PR DESCRIPTION
The "7"|8.? case in centos checks version changed to 7*|8* to allow scylla installation on centos8, rocky8.* and etc.