### PR TITLE
server: fix for installing nightly-master version + github-actions: adding nightly-master version test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,13 @@ jobs:
       - uses: actions/checkout@v2
       - run: sudo ./server --scylla-version 4.5
 
+  test_nightly_master:
+    name: Test installation for nightly-master version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo ./server --scylla-version nightly-master
+
   test_latest:
     name: Test installation for latest version
     runs-on: ubuntu-latest

--- a/server
+++ b/server
@@ -188,7 +188,7 @@ setup_install() {
 }
 
 get_full_version() {
-  PATCH_VERSION=$(echo $SCYLLA_VERSION | cut -d'.' -f 3)
+  PATCH_VERSION=$(echo $SCYLLA_VERSION | awk -v FS='.' '{print $3}')
  if [ -n "$PATCH_VERSION" ] && [ -z "$DEFAULT_SCYLLA_VERSION" ] || [[ $SCYLLA_VERSION == *rc* ]]; then
     FULL_SCYLLA_VERSION=$(apt-cache madison ${SCYLLA_PRODUCT} | grep $SCYLLA_VERSION | cut -d'|' -f 2 | sed 's/[[:space:]]//g')
     if [[ $SCYLLA_PRODUCT =~ "enterprise" ]]; then


### PR DESCRIPTION
fix for installing nightly-master version, instead of cut specific version using awk.
Adding test for nightly-master version in github-actions (test.yml)