### PR TITLE
server:remove epel installation from rhel and oracle

### DIFF
--- a/server
+++ b/server
@@ -30,7 +30,7 @@
 # DEBUG OPTIONS:
 # [--scylla-repo-file-url <url>] URL to test installation from a custom URL.
 # DEBUG FLAGS:
-# [--debug-run] - use slim/minimal dockers when needed, and skip epel installation.
+# [--debug-run] - use slim/minimal dockers when needed
 # [--dry-run] -   Prints out commands instead of executing them.
 # [--verbose] -   Runs install commands with no quiet option, and more info.
 #
@@ -329,7 +329,7 @@ DEBUG OPTIONS:
   [--scylla-repo-file-url <url>] URL to test installation from a custom URL.
 
 DEBUG FLAGS:
-  [--debug-run] - use slim/minimal dockers when needed, and skip epel installation.
+  [--debug-run] - use slim/minimal dockers when needed.
   [--dry-run] -   Prints out commands instead of executing them.
   [--verbose] -   Runs install commands with no quiet option, and more info.
 
@@ -429,9 +429,6 @@ rhel_install() {
   fi
   echo_msg "Installing Scylla version $SCYLLA_VERSION for Red Hat Enterprise Linux ..."
   set_rpm_install_tool
-  if [ $DEBUG_RUN -eq 0 ]; then
-    run_cmd $RPM_INSTALL_TOOL install $YUM_QUIET_CMD_PARAM https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-  fi
   install_rpm
 }
 
@@ -453,9 +450,6 @@ ol_install() {
   fi
   echo_msg "Installing Scylla version $SCYLLA_VERSION for Oracle Linux ..."
   set_rpm_install_tool
-  if [ $DEBUG_RUN -eq 0 ]; then
-    run_cmd $RPM_INSTALL_TOOL install $YUM_QUIET_CMD_PARAM https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-  fi
   install_rpm
 }
 


### PR DESCRIPTION
In one of my debug sessions i got the following error:
```

[2022-06-07T06:21:59.928Z] Installing Scylla version nightly-master for Red Hat Enterprise Linux ...

[2022-06-07T06:22:04.092Z] Status code: 403 for https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm (IP: 38.145.60.24)

[2022-06-07T06:22:04.654Z] Error: error building at STEP "RUN ./server.sh $SCYLLA_PRODUCT_NAME $SCYLLA_VERSION $DRY_RUN $SCYLLA_REPO_FILE_URL": error while running runtime: exit status 1

script returned exit code 125
```

It seems that `epel` is not needed for the installation, so let's remove it